### PR TITLE
Exposed wrapped isAgility() to be able to test if objects are agility obj

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -897,11 +897,15 @@
   
   // For plugins
   agility.fn = defaultPrototype;
+  
+  // isAgility test
+  agility.isAgility = function(obj) {
+    if (typeof obj !== 'object') return false;
+    return util.isAgility(obj);
+  };
 
   // Globals
   window.agility = window.$$ = agility;
-
-
 
   // -----------------------------------------
   //

--- a/test/public/core.js
+++ b/test/public/core.js
@@ -657,6 +657,20 @@
     obj.view.$().trigger('click');
     ok(t===true, "root click event caught");
   });
+  
+  test("isAgility utility method", function() {
+    var obj = { some: 'object' };
+    equals($$.isAgility(obj), false, 'non-agility object should return false');
+    
+    obj = 'some string';
+    equals($$.isAgility(obj), false, 'string should return false');
+    
+    obj = 17;
+    equals($$.isAgility(obj), false, 'number should return false');
+    
+    obj = $$( {}, '<div/>' );
+    equals($$.isAgility(obj), true, 'agility object should return true');
+  });
 
 })(jQuery, agility);
 


### PR DESCRIPTION
I found it useful to be able to test if an object is an agility object. This is especially useful when used in tests and prevents having to mess with agility object internals ( `_agility` ).

This commit enables things like:

```
expect( $$.isAgility( obj ) ).toBeTrue();
```
