### PR TITLE
Added pre: and post: hooks to custom agility controller events

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -112,6 +112,19 @@
     } // for attr1
   }; // proxyAll
   
+  // Reverses the order of events attached to an object
+  util.reverseEvents = function(obj, eventType){
+    var events = $(obj).data('events');
+    if (events !== undefined && events[eventType] !== undefined){
+      // can't reverse what's not there
+      var reverseEvents = [];
+      for (var e in events[eventType]){
+        reverseEvents.unshift(events[eventType][e]);
+      }
+      events[eventType] = reverseEvents;
+    }
+  }; //reverseEvents
+  
   // Determines # of attributes of given object (prototype inclusive)
   util.size = function(obj){
     var size = 0, key;
@@ -291,7 +304,13 @@
         // Custom event
         else {
           $(this._events.data).trigger('_'+eventObj.type, params);
+          // fire 'pre' hooks in reverse attachment order ( last first )
+          util.reverseEvents(this._events.data, 'pre:' + eventObj.type);
+          $(this._events.data).trigger('pre:' + eventObj.type, params);
+          // put the order of events back
+          util.reverseEvents(this._events.data, 'pre:' + eventObj.type);
           $(this._events.data).trigger(eventObj.type, params);
+          $(this._events.data).trigger('post:' + eventObj.type, params);
         }
         return this; // for chainable calls
       } // trigger

--- a/test/public/core.js
+++ b/test/public/core.js
@@ -208,6 +208,92 @@
     // equals( t2, o2, '_noProxy obj.*' );
   });
   
+  test("Bind to a controller custom event pre hook", function() {
+    var obj = $$({}, '<div/>', {
+      'myEvent': function() {
+        var l = $$({label: 'myEventLabel'}, '<span data-bind="label"/>');
+        this.append(l);
+      }
+    });
+    var ob = $$(obj);
+    validateObject(ob);
+    ob.bind('pre:myEvent', function() {
+      var l = $$({label: 'preHookEvent'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    //$$.document.append( ob );
+    ob.trigger('myEvent');
+    equals( ob.view.$( 'span' ).first().html(), 'preHookEvent', 'preHook event fired');
+    equals( ob.view.$( 'span' ).last().html(), 'myEventLabel', 'original event fired');
+  });
+  
+  test("Bind to a controller custom event pre hook twice", function() {
+    var obj = $$({}, '<div/>', {
+      'myEvent': function() {
+        var l = $$({label: 'myEventLabel'}, '<span data-bind="label"/>');
+        this.append(l);
+      }
+    });
+    var ob = $$(obj);
+    validateObject(ob);
+    ob.bind('pre:myEvent', function() {
+      var l = $$({label: 'preHookEvent'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    ob.bind('pre:myEvent', function() {
+      var l = $$({label: 'preHookEventLastFirst'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    //$$.document.append( ob );
+    ob.trigger('myEvent');
+    equals( ob.view.$( 'span' ).first().html(), 'preHookEventLastFirst', 'last preHook event fired first');
+    equals( ob.view.$( 'span' ).eq(1).html(), 'preHookEvent', 'preHook event fired');
+    equals( ob.view.$( 'span' ).last().html(), 'myEventLabel', 'original event fired');
+  });
+  
+  test("Bind to a controller custom event post hook", function() {
+    var obj = $$({}, '<div/>', {
+      'myEvent': function() {
+        var l = $$({label: 'myEventLabel'}, '<span data-bind="label"/>');
+        this.append(l);
+      }
+    });
+    var ob = $$(obj);
+    validateObject(ob);
+    ob.bind('post:myEvent', function() {
+      var l = $$({label: 'postHookEvent'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    //$$.document.append( ob );
+    ob.trigger('myEvent');
+    equals( ob.view.$( 'span' ).first().html(), 'myEventLabel', 'original event fired');
+    equals( ob.view.$( 'span' ).last().html(), 'postHookEvent', 'postHook event fired');
+  });
+  
+  test("Bind to a controller custom event post hook twice", function() {
+    var obj = $$({}, '<div/>', {
+      'myEvent': function() {
+        var l = $$({label: 'myEventLabel'}, '<span data-bind="label"/>');
+        this.append(l);
+      }
+    });
+    var ob = $$(obj);
+    validateObject(ob);
+    ob.bind('post:myEvent', function() {
+      var l = $$({label: 'postHookEvent'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    ob.bind('post:myEvent', function() {
+      var l = $$({label: 'postHookEventLastLast'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    //$$.document.append( ob );
+    ob.trigger('myEvent');
+    equals( ob.view.$( 'span' ).first().html(), 'myEventLabel', 'original event fired');
+    equals( ob.view.$( 'span' ).eq(1).html(), 'postHookEvent', 'postHook event fired');
+    equals( ob.view.$( 'span' ).last().html(), 'postHookEventLastLast', 'last postHook event fired last');
+  });
+  
   test("Extend controller syntax from four arguments (prototype, model, view, controller object)", function() {
     var lbl = $$({}, '<span data-bind="label"/>');
     var partial = $$({}, '<div/>', {


### PR DESCRIPTION
If an agility object has a custom agility event. One can bind to a `pre:` or `post:` hook. For example:

```
var obj = $$({}, '<div/>', {
  'myEvent': function() {
    var l = $$({label: 'myEventLabel'}, '<span data-bind="label"/>');
    this.append(l);
  }
});
obj.bind('post:myEvent', function() {
  var l = $$({label: 'postHookEvent'}, '<span data-bind="label"/>');
  obj.append(l);
});
obj.bind('pre:myEvent', function() {
  var l = $$({label: 'preHookEvent'}, '<span data-bind="label"/>');
  obj.append(l);
});
```
