### PR TITLE
Implemented pre:appended and post:appended hooks being called on appended object

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -640,24 +640,32 @@
 
       // Triggered after child obj is appended to container
       _append: function(event, obj, selector){
+        obj.trigger('pre:appended');
         this.view.$(selector).append(obj.view.$());
+        obj.trigger('post:appended');
       },
 
       // Triggered after child obj is prepended to container
       _prepend: function(event, obj, selector){
+        obj.trigger('pre:appended');
         this.view.$(selector).prepend(obj.view.$());
+        obj.trigger('post:appended');
       },
 
       // Triggered after child obj is inserted in the container
       _before: function(event, obj, selector){
         if (!selector) throw 'agility.js: _before needs a selector';
+        obj.trigger('pre:appended');
         this.view.$(selector).before(obj.view.$());
+        obj.trigger('post:appended');
       },
 
       // Triggered after child obj is inserted in the container
       _after: function(event, obj, selector){
         if (!selector) throw 'agility.js: _after needs a selector';
+        obj.trigger('pre:appended');
         this.view.$(selector).after(obj.view.$());
+        obj.trigger('post:appended');
       },
 
       // Triggered after a child obj is removed from container (or self-removed)

--- a/test/public/core.js
+++ b/test/public/core.js
@@ -485,6 +485,52 @@
     obj1.empty();
     equals(obj1.size(), 0, 'empty() works');
   });
+  
+  test("Container calls pre and post 'appended' hooks on object being appended", function() {
+    var obj1 = $$({}, '<div><span class="here"></span></div>');
+    var obj2 = $$({ text: 'hello' }, '<div data-bind="text"/>');
+    var obj3 = $$(obj2, { 
+      controller: {
+        'pre:appended': function() {
+          var hello = this.model.get( 'text' );
+          hello += '-pre';
+          this.model.set({text: hello});
+        },
+        'post:appended': function() {
+          var hello = this.model.get( 'text' );
+          hello += '-post';
+          this.model.set({text: hello});
+        }
+      }
+    });
+    obj1.append(obj3, '.here');
+    equals(obj1.view.$('.here div').html(), 'hello-pre-post', 'append() triggered appended hooks');
+    
+    obj1 = $$({}, '<div><ul/></div>');
+    obj3.model.set({text: 'hello'});
+    obj1.prepend(obj3);
+    equals(obj1.view.$('ul').prev().html(), 'hello-pre-post', 'prepend() triggered appended hooks');
+    
+    obj1 = $$({}, '<div><ul><li id="a"/> <li id="b"/></ul></div>');
+    obj3.model.set({text: 'hello'});
+    obj1.before(obj3, '#b');
+    equals(obj1.view.$('ul li#a').next().html(), 'hello-pre-post', 'before() triggered appended hooks');
+    
+    obj1 = $$({}, '<div><ul><li id="a"/> <li id="b"/></ul></div>');
+    obj3.model.set({text: 'hello'});
+    obj1.after(obj3, '#a');
+    equals(obj1.view.$('ul li#a').next().html(), 'hello-pre-post', 'after() triggered appended hooks');
+    
+    var obj4 = $$(obj3, {
+      view: {
+        format: '<div id="obj4" data-bind="text"/>'
+      }
+    });
+    obj4.model.set({text: 'hello'});
+    $$.document.append(obj4);
+    equals($$.document.view.$('#obj4').html(), 'hello-pre-post', 'appended hooks triggered appended to document');
+    $$.document.view.$('#obj4').remove();
+  });
 
   test("Model calls", function(){
     var t = false;


### PR DESCRIPTION
In our experience with Internet Explorer, we often come across a problem where our 'create' controller attempts to format agility widgets using properties such as width(), position(), etc. A quick fix is to append the object to the DOM, and then run the configuration requiring those properties by triggering a controller. However, this breaks our widget encapsulation. The solution is to provide hooks for before and after the object is appended in order to complete any type of configuration. This way, the users of the widget won't forget to manually trigger controllers and the widgets will work as intended.
