### PR TITLE
Fixed a bug in my implementation of util.reverseEvents

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -119,6 +119,7 @@
       // can't reverse what's not there
       var reverseEvents = [];
       for (var e in events[eventType]){
+        if (!events[eventType].hasOwnProperty(e)) continue;
         reverseEvents.unshift(events[eventType][e]);
       }
       events[eventType] = reverseEvents;

--- a/test/public/core.js
+++ b/test/public/core.js
@@ -221,10 +221,32 @@
       var l = $$({label: 'preHookEvent'}, '<span data-bind="label"/>');
       ob.append(l);
     });
-    //$$.document.append( ob );
     ob.trigger('myEvent');
     equals( ob.view.$( 'span' ).first().html(), 'preHookEvent', 'preHook event fired');
     equals( ob.view.$( 'span' ).last().html(), 'myEventLabel', 'original event fired');
+  });
+  
+  test("Bind to a controller custom event pre hook event reversal 'has own property bug' regression test", function () {
+    var obj = $$({}, '<div/>', {
+      'myEvent': function() {
+        var l = $$({label: 'myEventLabel'}, '<span data-bind="label"/>');
+        this.append(l);
+      }
+    });
+    var ob = $$(obj);
+    validateObject(ob);
+    ob.bind('pre:myEvent', function() {
+      var l = $$({label: 'preHookEvent'}, '<span data-bind="label"/>');
+      ob.append(l);
+    });
+    Array.prototype.__myRandomFunction = function() {
+      return 'not own property that will exists on events array';
+    };
+    ob.trigger('myEvent');
+    equals(ob.view.$('span').first().html(), 'preHookEvent', 'preHook event fired');
+    equals(ob.view.$('span').last().html(), 'myEventLabel', 'original event fired');
+    delete Array.prototype.__myRandomFunction;
+    ok(typeof Array.prototype.__myRandomFunction === 'undefined', 'reverted to original Array prototype');
   });
   
   test("Bind to a controller custom event pre hook twice", function() {


### PR DESCRIPTION
Fixed a bug in util.reverseEvents ( was missing hasOwnProperty check in "for _ in _" loop ).

Array.prototype.indexOf was getting attached as an event and causing:

``` javascript
"Uncaught TypeError: Cannot call method 'apply' of undefined"
```

@arturadib what are your thoughts on where regression tests like the one attached here should go?
