### PR TITLE
Fixing persistence inheritance

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -799,7 +799,6 @@
 
     // Fresh 'own' properties (i.e. properties that are not inherited at all)
     object._id = idCounter++;
-    object._data = {};
     object._events.data = {}; // event bindings will happen below
     object._container.children = {};
     object.view.$root = $(); // empty jQuery object
@@ -807,6 +806,7 @@
     // Cloned own properties (i.e. properties that are inherited by direct copy instead of by prototype chain)
     // This prevents children from altering parents models
     object.model._data = prototype.model._data ? $.extend(true, {}, prototype.model._data) : {};
+    object._data = prototype._data ? $.extend(true, {}, prototype._data) : {};
 
     // -----------------------------------------
     //
@@ -924,7 +924,7 @@
     }
   });
   
-  // For plugins
+  // Shortcut to prototype for plugins
   agility.fn = defaultPrototype;
   
   // isAgility test
@@ -944,11 +944,10 @@
   
   // Main initializer
   agility.fn.persist = function(adapter, params){
-    var self = this,
-        id = 'id'; // name of id attribute
+    var id = 'id'; // name of id attribute
         
-    self._data.persist = $.extend({adapter:adapter}, params);
-    self._data.persist.openRequests = 0;
+    this._data.persist = $.extend({adapter:adapter}, params);
+    this._data.persist.openRequests = 0;
     if (params && params.id) {
       id = params.id;
     }
@@ -958,14 +957,15 @@
     // .save()
     // Creates new model or update existing one, depending on whether model has 'id' property
     this.save = function(){
-      if (self._data.persist.openRequests === 0) {
-        self.trigger('persist:start');
+      var self = this;
+      if (this._data.persist.openRequests === 0) {
+        this.trigger('persist:start');
       }
-      self._data.persist.openRequests++;
-      self._data.persist.adapter.call(self, {
-        type: self.model.get(id) ? 'PUT' : 'POST', // update vs. create
-        id: self.model.get(id),
-        data: self.model.get(),
+      this._data.persist.openRequests++;
+      this._data.persist.adapter.call(this, {
+        type: this.model.get(id) ? 'PUT' : 'POST', // update vs. create
+        id: this.model.get(id),
+        data: this.model.get(),
         complete: function(){
           self._data.persist.openRequests--;
           if (self._data.persist.openRequests === 0) {
@@ -995,13 +995,14 @@
     // .load()
     // Loads model with given id
     this.load = function(){
+      var self = this;
       if (this.model.get(id) === undefined) throw 'agility.js: load() needs model id';
     
-      if (self._data.persist.openRequests === 0) {
-        self.trigger('persist:start');
+      if (this._data.persist.openRequests === 0) {
+        this.trigger('persist:start');
       }
-      self._data.persist.openRequests++;
-      self._data.persist.adapter.call(self, {
+      this._data.persist.openRequests++;
+      this._data.persist.adapter.call(this, {
         type: 'GET',
         id: this.model.get(id),
         complete: function(){
@@ -1026,13 +1027,14 @@
     // .erase()
     // Erases model with given id
     this.erase = function(){
+      var self = this;
       if (this.model.get(id) === undefined) throw 'agility.js: erase() needs model id';
     
-      if (self._data.persist.openRequests === 0) {
-        self.trigger('persist:start');
+      if (this._data.persist.openRequests === 0) {
+        this.trigger('persist:start');
       }
-      self._data.persist.openRequests++;
-      self._data.persist.adapter.call(self, {
+      this._data.persist.openRequests++;
+      this._data.persist.adapter.call(this, {
         type: 'DELETE',
         id: this.model.get(id),
         complete: function(){
@@ -1056,8 +1058,8 @@
 
     // .gather()
     // Loads collection and appends/prepends (depending on method) at selector. All persistence data including adapter comes from proto, not self
-    this.gather = function(proto, method, selectorOrQuery, query){
-      var selector;
+    this.gather = function(proto, method, selectorOrQuery, query){      
+      var selector, self = this;
       if (!proto) throw "agility.js plugin persist: gather() needs object prototype";
       if (!proto._data.persist) throw "agility.js plugin persist: prototype doesn't seem to contain persist() data";
 
@@ -1075,10 +1077,10 @@
         }
       }
 
-      if (self._data.persist.openRequests === 0) {
-        self.trigger('persist:start');
+      if (this._data.persist.openRequests === 0) {
+        this.trigger('persist:start');
       }
-      self._data.persist.openRequests++;
+      this._data.persist.openRequests++;
       proto._data.persist.adapter.call(proto, {
         type: 'GET',
         data: query,
@@ -1104,10 +1106,10 @@
       });
     
       return this; // for chainable calls
-    };
-
+    }; // gather()
+  
     return this; // for chainable calls
-  };
+  }; // fn.persist()
   
   // Persistence adapters
   // These are functions. Required parameters:

--- a/test/public/persist.js
+++ b/test/public/persist.js
@@ -2,8 +2,8 @@
 
   module("Persistence");
   
-  asyncTest("Server check", function(){
-    expect(16);
+  asyncTest("Server check", function() {
+    expect(28);
 
     // server check
     $.get('/api/', function(res){
@@ -61,10 +61,7 @@
     // container - gather, first syntax
     var proto = $$({}, '<li data-bind="name"></li>',{
       'create': function(){
-        if (!this._createCalled) {
-          ok(true, "proto 'create' called");
-          this._createCalled = true;
-        }
+        ok(true, "proto 'create' called");
       }
     }).persist($$.adapter.restful, {collection:'people'});
     var obj = $$({}, '<ul></ul>', {
@@ -74,14 +71,11 @@
       }
     }).persist();
     obj.gather(proto, 'append'); // gather
-
+    
     // container - gather, second syntax
     var proto = $$({}, '<li data-bind="name"></li>', {
       'create': function(){
-        if (!this._createCalled) {
-          ok(true, "proto 'create' called");
-          this._createCalled = true;
-        }
+        ok(true, "proto 'create' called");
       }
     }).persist($$.adapter.restful, {collection:'people'});
     var obj = $$({}, '<div><ul></ul></div>', {
@@ -95,10 +89,7 @@
     // container - gather, third syntax
     var proto = $$({}, '<li data-bind="name"></li>', {
       'create': function(){
-        if (!this._createCalled) {
-          ok(true, "proto 'create' called");
-          this._createCalled = true;
-        }
+        ok(true, "proto 'create' called");
       }
     }).persist($$.adapter.restful, {collection:'people'});
     var obj = $$({}, '<ul></ul>', {
@@ -108,6 +99,22 @@
       }
     }).persist();
     obj.gather(proto, 'append', {some:'parameter'}); // gather
+
+    // test gather-modify-save consistency
+    var proto = $$({}, '<li data-bind="name"></li>', {
+      'persist:save:success': function(){
+        equals(this.model.get('name'), 'NEW NAME', 'saved modified model');
+      }
+    }).persist($$.adapter.restful, {collection:'people'});
+    var obj = $$({}, '<ul></ul>', {
+      'persist:gather:success': function(event, res){
+        this.each(function() {
+          this.model.set({'name': 'NEW NAME'});
+          this.save();
+        });
+      }
+    }).persist();
+    obj.gather(proto, 'append'); // gather
 
     setTimeout(function(){
       start();


### PR DESCRIPTION
@tristanls Can you please double-check this?

@davidascher found a bug with the persistence plugin, when the object to be persisted (e.g. `.save()`) inherits from a prototype.
