### PR TITLE
fix for #30; added firing change event when field is not present in model.set but reset=true

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -331,13 +331,19 @@
         var self = this;
         var modified = []; // list of modified model attributes
         if (typeof arg === 'object') {
+          var _clone = false;
           if (params && params.reset) {
+            _clone = this.model._data; // hold on to data for change events
             this.model._data = $.extend({}, arg); // erases previous model attributes without pointing to object
           }
           else {
             $.extend(this.model._data, arg); // default is extend
           }
           for (var key in arg) {
+            delete _clone[ key ]; // no need to fire change twice
+            modified.push(key);
+          }
+          for (key in _clone) {
             modified.push(key);
           }
         }

--- a/test/public/core.js
+++ b/test/public/core.js
@@ -897,8 +897,12 @@
   });
 
   test("Model calls", function(){
+    var a_change = false;
     var t = false;
     var obj1 = $$({a:1}, '<div data-bind="text"></div>', {
+      'change:a': function(){
+        a_change = true;
+      },
       'change:text': function(){
         t = true;
       }
@@ -907,8 +911,10 @@
     equals(obj1.model.get('a'), 1, 'obj.model.set() extends by default');
     equals(obj1.view.$().text(), 'Joe Doe', 'obj.model.set() fires view change');
     equals(t, true, 'obj.model.set() fires change:var');
+    a_change = false;
     obj1.model.set({text:'New Text'}, {reset:true});
     equals(obj1.model.get('a'), undefined, 'obj.model.set() resets OK');
+    equals(a_change, true, 'obj.model.set() with reset=true fires change:a');
     
     obj1.model.reset();
     equals(obj1.model.get('a'), 1, 'obj.model.reset() brings back original attribute');


### PR DESCRIPTION
I modeled the fix on @individual11 input and took the approach of just running the tests and they pass.

I don't quite understand the issue with inability to use _toString()_ that he brought up. Is that still a problem?

edit: saying -> #30 so it shows up in that discussion
