### PR TITLE
More flexible event binding

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -803,10 +803,6 @@
       this._events.bindFrom.apply(this, arguments);
       return this;
     },
-    unbind: function(){
-      this._events.unbind.apply(this, arguments);
-      return this; // for chainable calls
-    },
     trigger: function(){
       this._events.trigger.apply(this, arguments);
       return this; // for chainable calls

--- a/docs/_docs.md
+++ b/docs/_docs.md
@@ -518,6 +518,36 @@ _Binds function to event._
 
 Owner Agility object (for chainable calls).
 
+### [.bindFrom()](#core-bindfrom)
+
+_Binds a function to event from an "origin object".
+When the origin object is destroyed, the event handler is automatically unbound.
+Useful for short-lived objects that bind to events in more long-lived objects._
+
+**Syntax:**
+
+    :::javascript
+    .bindFrom(originObject, event, fn)
+
++ `originObject`: Origin object that causes the event to be unbound when it is destroyed.
++ `event`: String specifying event type. Only Agility events are supported.
++ `fn`: function to be called upon event triggering.
+
+**Example:**
+
+    :::javascript
+    var model = $$({key: 'value'});
+    var observer = $$();
+    model.bindFrom(observer, 'change', someHandler);
+    // someHandler will now be called on model changes
+    observer.destroy();
+    // someHandler is now automatically unbound
+
+**Returns:**
+
+Owner Agility object (for chainable calls).
+
+
 ### [.trigger()](#core-trigger)
 
 _Triggers event, optionally passing parameters to listeners._

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -569,6 +569,32 @@
 </ul>
 <p><strong>Returns:</strong></p>
 <p>Owner Agility object (for chainable calls).</p>
+<h3><a href="#core-bindfrom">.bindFrom()</a></h3>
+<p><em>Binds a function to event from an "origin object".
+When the origin object is destroyed, the event handler is automatically unbound.
+Useful for short-lived objects that bind to events in more long-lived objects.</em></p>
+<p><strong>Syntax:</strong></p>
+<div class="codehilite"><pre><span class="p">.</span><span class="nx">bindFrom</span><span class="p">(</span><span class="nx">originObject</span><span class="p">,</span> <span class="nx">event</span><span class="p">,</span> <span class="nx">fn</span><span class="p">)</span>
+</pre></div>
+
+
+<ul>
+<li><code>originObject</code>: Origin object that causes the event to be unbound when it is destroyed.</li>
+<li><code>event</code>: String specifying event type. Only Agility events are supported.</li>
+<li><code>fn</code>: function to be called upon event triggering.</li>
+</ul>
+<p><strong>Example:</strong></p>
+<div class="codehilite"><pre><span class="kd">var</span> <span class="nx">model</span> <span class="o">=</span> <span class="nx">$$</span><span class="p">({</span><span class="nx">key</span><span class="o">:</span> <span class="s1">&#39;value&#39;</span><span class="p">});</span>
+<span class="kd">var</span> <span class="nx">observer</span> <span class="o">=</span> <span class="nx">$$</span><span class="p">();</span>
+<span class="nx">model</span><span class="p">.</span><span class="nx">bindFrom</span><span class="p">(</span><span class="nx">observer</span><span class="p">,</span> <span class="s1">&#39;change&#39;</span><span class="p">,</span> <span class="nx">someHandler</span><span class="p">);</span>
+<span class="c1">// someHandler will now be called on model changes</span>
+<span class="nx">observer</span><span class="p">.</span><span class="nx">destroy</span><span class="p">();</span>
+<span class="c1">// someHandler is now automatically unbound</span>
+</pre></div>
+
+
+<p><strong>Returns:</strong></p>
+<p>Owner Agility object (for chainable calls).</p>
 <h3><a href="#core-trigger">.trigger()</a></h3>
 <p><em>Triggers event, optionally passing parameters to listeners.</em></p>
 <p><strong>Syntax:</strong> </p>

--- a/test/public/core.js
+++ b/test/public/core.js
@@ -1082,7 +1082,7 @@
     o.trigger('testevent');
     ok(eventCalled, "event handler called after bind");
     eventCalled = false;
-    o.unbind('testevent');
+    o._events.unbind('testevent');
     o.trigger('testevent');
     ok(!eventCalled, "event handler not called after unbind");
   });


### PR DESCRIPTION
Adds a public method `bindFrom` and private method `unbind` to enable more powerful event binding.

`bindFrom` is useful for short-lived objects to subscribe to events in long-lived, shared, or global objects. For example, many temporary objects may want to subscribe to a certain model key in a global settings object.  When using just `bind`, many event handlers can pile up on long-lived objects and there can be other undesired side effects from event handlers being called on destroyed objects. `bindFrom` also provides part of the foundation for eventual model-model bindings.

`bindFrom` only works with Agility events because of the limited use-cases for dynamically binding and unbinding DOM events.

`unbind` is a private method used to implement `bindFrom`. It's private to discourage unbinding of all handlers for a name rather than the selective unbinding provided by `bindFrom`.
