### PR TITLE
Fix for issue #93 which caused the library to break in older versions of IE.

### DIFF
--- a/agility.js
+++ b/agility.js
@@ -922,7 +922,7 @@
       var events = eventStr.split(';');
       var handler = object.controller[eventStr];
       $.each(events, function(i, ev){
-        ev = ev.trim();
+        ev = $.trim(ev);
         bindEvent(ev, handler);
       });
     }


### PR DESCRIPTION
IE < version 9 doesn't support el.trim(), switched to JQuery $.trim() instead.
